### PR TITLE
Add grep

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Some example text
 * echo — display arguments
 * wc [FILE] — print number of lines, words and byte
 * pwd — display current working directory
+* grep [-i] [-w] [-A n] PATTERN [FILE] — display current working directory
 * exit — exit cli
 * Note: if unknown command entered then external command will be called through java Process 
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.3.72'
 }
 
+apply plugin: 'kotlin-kapt'
+
 group 'me.spb.hse.nikolyukin'
 version '1.0-SNAPSHOT'
 
@@ -26,6 +28,8 @@ dependencies {
     implementation 'com.github.h0tk3y.betterParse:better-parse:0.4.0'
 
     implementation "org.koin:koin-core:2.1.6"
+    compile 'info.picocli:picocli:4.5.1'
+    kapt 'info.picocli:picocli-codegen:4.5.1'
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
     testImplementation('org.junit.jupiter:junit-jupiter-params:5.6.2')
@@ -36,6 +40,13 @@ test {
     useJUnitPlatform()
     testLogging {
         events("passed", "skipped", "failed")
+    }
+}
+
+// for picocli
+kapt {
+    arguments {
+        arg("project", "${project.group}/${project.name}")
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+kapt.incremental.apt=true

--- a/src/main/kotlin/me/spb/hse/nikolyukin/cli/shell/DefaultExecutionCommandFactory.kt
+++ b/src/main/kotlin/me/spb/hse/nikolyukin/cli/shell/DefaultExecutionCommandFactory.kt
@@ -18,6 +18,7 @@ class DefaultExecutionCommandFactory : ExecutionCommandFactory {
             "echo" -> ExecutionEcho(command.args.map { it.value })
             "exit" -> ExecutionExit(environment)
             "pwd" -> ExecutionPwd(environment)
+            "grep" -> ExecutionGrep(environment.workingDir, command.args.map { it.value })
             "wc" -> {
                 ExecutionWc(environment.workingDir, command.args.getOrNull(0)?.let { Path.of(it.value) })
             }

--- a/src/main/kotlin/me/spb/hse/nikolyukin/cli/shell/executable/ExecutionGrep.kt
+++ b/src/main/kotlin/me/spb/hse/nikolyukin/cli/shell/executable/ExecutionGrep.kt
@@ -26,11 +26,11 @@ class ExecutionGrep(private val workingDir: Path, args: List<String>) : Executio
     private val opt: Set<RegexOption>
 
     init {
+        CommandLine(this).parseArgs(*args.toTypedArray())
         if (afterContext < 0) {
             throw ShellException("grep: $afterContext: invalid context length argument")
         }
-        CommandLine(this).parseArgs(*args.toTypedArray())
-        opt = sequence<RegexOption> {
+        opt = sequence {
             if (ignoreCase) yield(RegexOption.IGNORE_CASE)
         }.toSet()
 

--- a/src/main/kotlin/me/spb/hse/nikolyukin/cli/shell/executable/ExecutionGrep.kt
+++ b/src/main/kotlin/me/spb/hse/nikolyukin/cli/shell/executable/ExecutionGrep.kt
@@ -1,0 +1,60 @@
+package me.spb.hse.nikolyukin.cli.shell.executable
+
+import me.spb.hse.nikolyukin.cli.shell.ShellException
+import picocli.CommandLine
+import picocli.CommandLine.Option
+import picocli.CommandLine.Parameters
+import java.io.InputStream
+import java.nio.file.Path
+
+class ExecutionGrep(private val workingDir: Path, args: List<String>) : ExecutionCommand {
+    @Option(names = ["-i"])
+    private var ignoreCase: Boolean = false
+
+    @Option(names = ["-w"])
+    private var wordRegex: Boolean = false
+
+    @Option(names = ["-A"])
+    private var afterContext: Int = 0
+
+    @Parameters(paramLabel = "PATTERN", index = "0")
+    private lateinit var patternString: String
+
+    @Parameters(paramLabel = "FILE", index = "1", arity = "0..1")
+    private var filePath: Path? = null
+
+    private val opt: Set<RegexOption>
+
+    init {
+        if (afterContext < 0) {
+            throw ShellException("grep: $afterContext: invalid context length argument")
+        }
+        CommandLine(this).parseArgs(*args.toTypedArray())
+        opt = sequence<RegexOption> {
+            if (ignoreCase) yield(RegexOption.IGNORE_CASE)
+        }.toSet()
+
+        if (wordRegex) {
+            patternString = "\\b$patternString\\b"
+        }
+    }
+
+    override fun execute(stdin: InputStream): OutChannels {
+        val outBuilder = mutableListOf<String>()
+        val regex = patternString.toRegex(opt)
+        val inputReader = filePath?.let { workingDir.resolve(it).toFile().bufferedReader() } ?: stdin.bufferedReader()
+        inputReader.useLines {
+            var contextLeft = 0
+            it.forEach { s ->
+                if (regex.find(s) != null) {
+                    outBuilder.add(s)
+                    contextLeft = afterContext
+                } else if (contextLeft > 0) {
+                    outBuilder.add(s)
+                    contextLeft--
+                }
+            }
+        }
+        return OutChannels(outBuilder.joinToString("\n").byteInputStream(), "".byteInputStream())
+    }
+}

--- a/src/test/kotlin/me/spb/hse/nikolyukin/cli/shell/executable/ExecutionCommandTest.kt
+++ b/src/test/kotlin/me/spb/hse/nikolyukin/cli/shell/executable/ExecutionCommandTest.kt
@@ -15,7 +15,7 @@ open class ExecutionCommandTest {
     protected lateinit var homePathString: String
 
     @BeforeEach
-    fun init() {
+    private fun init() {
         env = EnvironmentByMapImpl(mutableMapOf())
         env.status = ShellStatus.RUNNING
         env.workingDir = homePath

--- a/src/test/kotlin/me/spb/hse/nikolyukin/cli/shell/executable/ExecutionGrepTest.kt
+++ b/src/test/kotlin/me/spb/hse/nikolyukin/cli/shell/executable/ExecutionGrepTest.kt
@@ -1,0 +1,38 @@
+package me.spb.hse.nikolyukin.cli.shell.executable
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal class ExecutionGrepTest : ExecutionCommandTest() {
+
+    private lateinit var file: Path
+    private val fileName = "file.txt"
+
+    @BeforeEach
+    fun init() {
+        file = homePath.resolve(fileName)
+        Files.createFile(file)
+    }
+
+    @Test
+    fun executeWithFileAndIWOptins() {
+        val lines = listOf("0) a", "1) A", "2) abc")
+        val text = lines.joinToString("\n")
+        Files.writeString(file, text)
+        val exe = ExecutionGrep(homePath, listOf("a", "-i", "-w", fileName))
+        val out = exe.execute("".byteInputStream()).stdout.bufferedReader().readText()
+        assertEquals("${lines[0]}\n${lines[1]}", out)
+    }
+
+    @Test
+    fun executeWithPipeAndContext() {
+        val lines = listOf("0) text0", "1) text1", "2) text2", "3) text3")
+        val text = lines.joinToString("\n")
+        val exe = ExecutionGrep(homePath, listOf("text1", "-A", "1"))
+        val out = exe.execute(text.byteInputStream()).stdout.bufferedReader().readText()
+        assertEquals("${lines[1]}\n${lines[2]}", out)
+    }
+}


### PR DESCRIPTION
Grep использует библиотеку [picocli](https://github.com/remkop/picocli) для разбора аргументов.

Так же рассматривались следующие библиотеки:
* [Kotlin-argparser](https://github.com/xenomachina/kotlin-argparser).
Удобный синтаксис, написана на kotlin, но распространяется под лицензией LGPL-2.1. Я так и не понял, какие именно проблемы это создает, но с ней явно что-то не так.  
* [Kotlin-cli](https://github.com/Kotlin/kotlinx-cli)
Синтаксис очень похож на kotlin-argparser, разрабатывается JetBrains, но все еще является экспериментальным.
* [Clikt](https://github.com/ajalt/clikt)
Написана на Kotlin, активно поддерживается, имеет богатый функционал, но синтаксис требует наследования и запуск через отдельный метод, что совершенно не подходит для интеграции в проект.
*  [Picocli](https://github.com/remkop/picocli)
Java библиотека на аннотациях, что хуже интегрируется с kotlin, чем нативные библиотеки, но она очень популярна, активно поддерживается, имеет очень богатый функционал и хорошо подходит как для разбора аргументов внутренних команд, а не только main.
*  [jcommander](https://github.com/cbeust/jcommander)
Тоже самое, что и предыдущее, но меньше активности в репозитории и меньше звезд. 
*  [Apache Commons CLI](https://github.com/apache/commons-cli)
Примерно тоже самое, что и 2 предыдущих, но без аннотаций, более громоздко и последний релиз в 2017. 